### PR TITLE
Fix the drifting and the robot rotating downward when moving forward

### DIFF
--- a/scripts/cmd_vel_filter.py
+++ b/scripts/cmd_vel_filter.py
@@ -3,23 +3,29 @@ import rospy
 from geometry_msgs.msg import Twist
 from carla_msgs.msg import CarlaEgoVehicleControl
 
+breaking = False
+
 def callback(msg):
-    # Invert the velocity and publish
-    msg.angular.x = -msg.angular.x
-    msg.angular.y = -msg.angular.y
-    msg.angular.z = -msg.angular.z*2
-    pub.publish(msg)
-    rospy.loginfo("Passing through target velocity")
-    
-    # Brake if target velocity is 0
-    # This prevents drifting when the target velocity is 0
-    if msg == Twist():
+    global breaking
+
+    if (msg.linear.x == 0) and (msg.linear.y == 0) and (msg.linear.z == 0) and (msg.angular.x == 0) and (msg.angular.y == 0) and (msg.angular.z == 0):
+        breaking = True
         control = CarlaEgoVehicleControl()
         control.throttle = 0.
         control.brake = 1.
         control.steer = 0.
         pub_control.publish(control)
-        rospy.loginfo("Braking as target velocity is 0")
+    elif breaking:
+        breaking = False
+        control = CarlaEgoVehicleControl()
+        control.brake = 0.
+        pub_control.publish(control)
+    else:
+        # Invert the velocity and publish
+        msg.angular.x = -msg.angular.x
+        msg.angular.y = -msg.angular.y
+        msg.angular.z = -msg.angular.z*2
+        pub.publish(msg)
 
 if __name__ == '__main__':
     # Initialize the node with rospy

--- a/scripts/cmd_vel_filter.py
+++ b/scripts/cmd_vel_filter.py
@@ -6,17 +6,17 @@ from carla_msgs.msg import CarlaEgoVehicleControl
 breaking = False
 
 def callback(msg):
-    global breaking
+    global braking
 
     if (msg.linear.x == 0) and (msg.linear.y == 0) and (msg.linear.z == 0) and (msg.angular.x == 0) and (msg.angular.y == 0) and (msg.angular.z == 0):
-        breaking = True
+        braking = True
         control = CarlaEgoVehicleControl()
         control.throttle = 0.
         control.brake = 1.
         control.steer = 0.
         pub_control.publish(control)
-    elif breaking:
-        breaking = False
+    elif braking:
+        braking = False
         control = CarlaEgoVehicleControl()
         control.brake = 0.
         pub_control.publish(control)


### PR DESCRIPTION
The main issue was that the brakes were never released, making the robot tilt when moving forward. 

Now, when the message `Twist.linear == (0,0,0), Twist.angular == (0,0,0)` is received, brakes are activated and the variable `braking` is set to **true**.  
When a speed is indicated and the robot is still braking, the brakes are released. Otherwise, the speed is transferred to `carla/ego_vehicle/control/set_target_velocity` with the usual processing.

